### PR TITLE
New version of neuroConstruct/CElegansNeuroML bundle

### DIFF
--- a/war/downloads.html
+++ b/war/downloads.html
@@ -134,7 +134,7 @@
 							</p>
 							<p class="lead span6">
 								We have imported the NeuroML connectome model for C. elegans into a <a href="http://www.neuroconstruct.org">neuroConstruct</a> project. Here's a <a href="https://github.com/openworm/OpenWorm/wiki/Running-the-C.-elegans-model-in-neuroConstruct">guide to getting started</a> with it.
-								<br/><br/><a class="btn btn-primary btn-large" href="https://www.dropbox.com/s/wzem2isez33966m/CElegansNeuroConstructBundle-snapshot-20131102.zip" target="_blank">neuroConstruct project</a>
+								<br/><br/><a class="btn btn-primary btn-large" href="https://www.dropbox.com/s/xdu1bh5sq2x1nx6/CElegansNeuroConstructBundle-snapshot-20140107.zip" target="_blank">neuroConstruct project</a>
 							</p>
 						</div>
 						<div class="row-fluid pagination-centered">


### PR DESCRIPTION
Updated to use the jogamp_j3d branch of neuroConstruct, as this has 3D libraries that work properly on recent versions of OS X.
