### PR TITLE
Fix link to jquery

### DIFF
--- a/repositories.html
+++ b/repositories.html
@@ -226,7 +226,7 @@
 		</footer>
 		<!-- Placed at the end of the document so the pages load faster -->
 		<script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>
-		<script src="js/jquery-1.8.3.min.js"></script>
+		<script src="js/jquery-3.2.1.js"></script>
 		<script type="text/javascript" src="js/yaml.js"></script>
 		<script type="text/javascript" src="js/repositories.js"></script>
 		<script type="text/javascript" src="js/cwl-hierarchy.js"></script>


### PR DESCRIPTION
jquery was updated but here is still pointing to the old version (a better way for this not to happen would be remove version name from file itself as it's inside in the header anyway)