### PR TITLE
Add left sidebar navigation to news page

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -169,8 +169,8 @@ function refreshNews() {
 }
 
 function loadFullNewsFeed() {
-    // Load full news feed with descriptions for news.html page
-    console.log('Loading full news feed...');
+    // Load full news feed with sidebar navigation for news.html page
+    console.log('Loading full news feed with sidebar...');
 
     $.ajax({
         url: 'https://api.allorigins.win/get?url=' + encodeURIComponent('https://openworm.tumblr.com/rss'),
@@ -186,7 +186,8 @@ function loadFullNewsFeed() {
 
             console.log('Found ' + items.length + ' items');
 
-            var html = '';
+            var mainHtml = '';
+            var navHtml = '<li class="nav-header">News Archive</li>';
             var count = 0;
 
             for (var i = 0; i < items.length && count < 25; i++) {
@@ -196,7 +197,7 @@ function loadFullNewsFeed() {
                 var link = item.querySelector('link').textContent;
                 var pubDate = new Date(item.querySelector('pubDate').textContent);
                 var dateStr = pubDate.toLocaleDateString('en-US', {
-                    month: 'long',
+                    month: 'short',
                     day: 'numeric',
                     year: 'numeric'
                 });
@@ -204,17 +205,29 @@ function loadFullNewsFeed() {
                 var descNode = item.querySelector('description');
                 var description = descNode ? descNode.textContent : '';
 
-                var borderStyle = (count < 24) ? 'border-bottom: 1px solid #eee;' : '';
+                // Create anchor ID from index
+                var anchorId = 'news-' + count;
 
-                html += '<li style="margin-bottom: 30px; padding-bottom: 20px; ' + borderStyle + '">';
-                html += '<h3 style="margin-top: 0;"><a href="' + link + '" target="_blank">' + title + '</a></h3>';
-                html += '<p class="muted" style="font-size: 14px; margin-bottom: 10px;">' + dateStr + '</p>';
-                html += '<div style="line-height: 1.6;">' + description + '</div>';
-                html += '</li>';
+                // Add to sidebar nav (if nav element exists)
+                navHtml += '<li><a href="#' + anchorId + '"><i class="fa fa-chevron-right"></i>' + dateStr + '</a></li>';
+
+                // Add to main content
+                var borderStyle = (count < 24) ? 'border-bottom: 1px solid #eee;' : '';
+                mainHtml += '<li id="' + anchorId + '" style="margin-bottom: 30px; padding-bottom: 20px; ' + borderStyle + '">';
+                mainHtml += '<h3 style="margin-top: 0;"><a href="' + link + '" target="_blank">' + title + '</a></h3>';
+                mainHtml += '<p class="muted" style="font-size: 14px; margin-bottom: 10px;">' + dateStr + '</p>';
+                mainHtml += '<div style="line-height: 1.6;">' + description + '</div>';
+                mainHtml += '</li>';
                 count++;
             }
 
-            $("#news-feed-full").html(html);
+            $("#news-feed-full").html(mainHtml);
+            
+            // Update sidebar nav if it exists
+            if ($("#news-nav").length) {
+                $("#news-nav").html(navHtml);
+            }
+            
             console.log('Rendered ' + count + ' items');
 
             // Make images responsive
@@ -238,6 +251,11 @@ function loadFullNewsFeed() {
             }
 
             $("#news-feed-full").html('<li class="muted" style="text-align: center; padding: 40px;">' + errorMsg + ' <a href="https://openworm.tumblr.com" target="_blank">View blog directly &raquo;</a></li>');
+            
+            // Update sidebar nav with fallback if it exists
+            if ($("#news-nav").length) {
+                $("#news-nav").html('<li class="nav-header">News Archive</li><li><a href="https://openworm.tumblr.com" target="_blank"><i class="fa fa-external-link"></i> View on Tumblr</a></li>');
+            }
         }
     });
 }

--- a/news.html
+++ b/news.html
@@ -59,8 +59,18 @@
     <div class="container">
 
       <div class="row">
-        <div class="span12">
+        <!-- Left sidebar with news index -->
+        <div class="span3 bs-docs-sidebar">
+          <ul id="news-nav" class="nav nav-list bs-docs-sidenav">
+            <li class="nav-header">News Archive</li>
+            <li style="text-align: center; padding: 20px;">
+              <i class="fa fa-spinner fa-spin"></i>
+            </li>
+          </ul>
+        </div>
 
+        <!-- Main content area -->
+        <div class="span9">
           <div class="page-header">
             <h2>Latest News</h2>
             <p class="muted">News items are pulled from our <a href="https://openworm.tumblr.com" target="_blank">Tumblr blog</a>.</p>
@@ -73,7 +83,6 @@
               <p class="muted">Loading news from Tumblr...</p>
             </li>
           </ul>
-
         </div>
       </div>
 
@@ -89,6 +98,7 @@
   <!-- Le javascript
        ================================================== -->
   <!-- Placed at the end of the document so the pages load faster -->
+  <script src="js/jquery.pjax.js"></script>
   <script src="js/bootstrap.js"></script>
   <script src="js/main.js"></script>
   <script>


### PR DESCRIPTION
## Summary
Adds a left sidebar with clickable date index to the news page, matching the layout used on science.html and other pages.

Fixes #203

## Changes

### news.html
- Changed layout from `span12` to `span3` (sidebar) + `span9` (content)
- Added `#news-nav` sidebar element with loading spinner
- Added missing `jquery.pjax.js` include

### js/main.js
- Updated `loadFullNewsFeed()` to populate the sidebar nav with clickable dates
- Each date links to an anchor on the corresponding article
- Gracefully handles case where sidebar doesn't exist (backwards compatible)

## Screenshots
The sidebar shows article dates (e.g. "Apr 5, 2026") — clicking scrolls to that article.

## Testing
1. `python3 -m http.server 8000`
2. Open `http://localhost:8000/news.html`
3. Verify sidebar appears on left with dates
4. Click a date — page scrolls to that article

<img width="1416" height="788" alt="image" src="https://github.com/user-attachments/assets/93fd123a-49d8-44ba-aa93-8d81073b4809" />
